### PR TITLE
Make possible to use an existing cluster for running the e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,13 @@ golangci-lint: $(GOLANGCILINT) ## Download golangci-lint
 $(GOLANGCILINT): $(LOCALBIN)
 	curl -sSfL $(GOLANGCI_URL) | sh -s -- -b $(LOCALBIN) $(GOLANGCI_VERSION)
 
+.PHONY: unit
+TEST_PACKAGES ?= ./pkg/...
+unit: ## Run unit tests
+	go test $(TEST_PACKAGES)
+
+.PHONY: e2e
+E2E_PACKAGES ?= ./test/e2e/...
+e2e: ## Run e2e tests
+	go test $(E2E_PACKAGES)
+

--- a/test/e2e/manager/manager_test.go
+++ b/test/e2e/manager/manager_test.go
@@ -24,7 +24,7 @@ import (
 func TestInstallation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	cluster := framework.ProvisionedCluster(t)
+	cluster := framework.ProvisionCluster(t)
 
 	// check that OLM is getting deployed automatically through the placement rule
 	addonClient, err := addonclientsetv1.NewForConfig(cluster.ClientConfig(t))


### PR DESCRIPTION
This aims at running the e2e tests in different environment flavors, not only kind.