### PR TITLE
Align module name with the names used for other non-core addons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module open-cluster-management.io/olm-addon
+module github.com/stolostron/olm-addon
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonmanager"
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 
-	"open-cluster-management.io/olm-addon/pkg/manager"
+	"github.com/stolostron/olm-addon/pkg/manager"
 )
 
 const (

--- a/test/e2e/manager/manager_test.go
+++ b/test/e2e/manager/manager_test.go
@@ -15,10 +15,10 @@ import (
 
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/stolostron/olm-addon/test/e2e/framework"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	addonclientsetv1 "open-cluster-management.io/api/client/addon/clientset/versioned/typed/addon/v1alpha1"
 	ocmclientsetv1 "open-cluster-management.io/api/client/cluster/clientset/versioned/typed/cluster/v1beta1"
-	"open-cluster-management.io/olm-addon/test/e2e/framework"
 )
 
 func TestInstallation(t *testing.T) {


### PR DESCRIPTION
e.g. github.com/stolostron/submariner-addon