### PR TITLE
Add a script for running e2e tests with kind from Prow

### DIFF
--- a/cicd/prow-e2e-kind.sh
+++ b/cicd/prow-e2e-kind.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+KEY="$SHARED_DIR/private.pem"
+chmod 400 "$KEY"
+
+IP="$(cat "$SHARED_DIR/public_ip")"
+HOST="ec2-user@$IP"
+OPT=(-q -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i "$KEY")
+
+scp "${OPT[@]}" -r ../olm-addon "$HOST:/tmp/olm-addon"
+ssh "${OPT[@]}" "$HOST" sudo sed -i 's~::1~#::1~g' /etc/hosts
+ssh "${OPT[@]}" "$HOST" sudo yum install git -y
+# to run as normal user
+# ssh "${OPT[@]}" "$HOST" sudo usermod -a -G docker '$USER'
+echo "running e2e tests"
+ssh "${OPT[@]}" "$HOST" "cd /tmp/olm-addon && make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
+if [[ $? -ne 0 ]]; then
+  echo "Failed to run e2e tests"
+  cat $ARTIFACT_DIR/test.log
+  exit 1
+fi


### PR DESCRIPTION
Necessary for prow integration, see [stolostron documentation](https://github.com/stolostron/cicd-docs/blob/d1d2df0f88f121c8f6e6f7dcd307caf74a907da6/prow/kind_tests.md#the-ocm-e2e-kind-workflow)