### PR TITLE
Moving to the new way of deploying OCM using clusteradm

### DIFF
--- a/cicd/prow-e2e-kind.sh
+++ b/cicd/prow-e2e-kind.sh
@@ -37,7 +37,7 @@ ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=2097152\
 
 echo "running e2e tests"
 set -o pipefail
-ssh "${OPT[@]}" "$HOST" "export GOROOT=/usr/lib/golang; export PATH=\$GOROOT/bin:\$PATH; echo \$PATH && cd /tmp/olm-addon && go version && kind version && go mod download && make build && export DEBUG=true; make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
+ssh "${OPT[@]}" "$HOST" "export GOROOT=/usr/lib/golang; export PATH=\$GOROOT/bin:/usr/local/bin:\$PATH; echo \$PATH && cd /tmp/olm-addon && go version && kind version && go mod download && make build && export DEBUG=true; make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
 if [[ $? -ne 0 ]]; then
   echo "Failure"
   cat $ARTIFACT_DIR/test.log

--- a/deploy/addon-manager/deployment.yaml
+++ b/deploy/addon-manager/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - args:
         - /addon-manager
         - manager
-        image: quay.io/open-cluster-management/addon-manager:latest
+        image: quay.io/open-cluster-management/addon-manager:v0.7.1
         imagePullPolicy: IfNotPresent
         name: addon-manager-controller
         securityContext:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.90.0
-	open-cluster-management.io/addon-framework v0.7.0
+	open-cluster-management.io/addon-framework v0.7.1
 	open-cluster-management.io/api v0.11.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -650,8 +650,8 @@ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+O
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 h1:KTgPnR10d5zhztWptI952TNtt/4u5h3IzDXkdIMuo2Y=
 k8s.io/utils v0.0.0-20221128185143-99ec85e7a448/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-open-cluster-management.io/addon-framework v0.7.0 h1:Y0of/15MU6jPERrcabN8t8Ng8XMXzohIr5g5InbHAlM=
-open-cluster-management.io/addon-framework v0.7.0/go.mod h1:UL2n40LeBaTDDMz8bbkz94c+HG248nH28TFLKv+qPK8=
+open-cluster-management.io/addon-framework v0.7.1 h1:+qAu+9tcdVgMG14Y5llhLJAJLqx+JlEAIjheTvp27x4=
+open-cluster-management.io/addon-framework v0.7.1/go.mod h1:UL2n40LeBaTDDMz8bbkz94c+HG248nH28TFLKv+qPK8=
 open-cluster-management.io/api v0.11.0 h1:zBxa33Co3wseLBF4HEJobhl0P6ygj+Drhe7Wrfo0/h8=
 open-cluster-management.io/api v0.11.0/go.mod h1:WgKUCJ7+Bf40DsOmH1Gdkpyj3joco+QLzrlM6Ak39zE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=


### PR DESCRIPTION
Using the registration-operator is deprecated. Moving to the approach in the OCM repository using clusteradm.