### PR TITLE
Speed up olm uninstall to unflake CI

### DIFF
--- a/cicd/prow-e2e-kind.sh
+++ b/cicd/prow-e2e-kind.sh
@@ -37,7 +37,7 @@ ssh "${OPT[@]}" "$HOST" "sudo sh -c 'echo \"fs.inotify.max_user_watches=2097152\
 
 echo "running e2e tests"
 set -o pipefail
-ssh "${OPT[@]}" "$HOST" "export GOROOT=/usr/lib/golang; export PATH=\$GOROOT/bin:/usr/local/bin:\$PATH; echo \$PATH && cd /tmp/olm-addon && go version && kind version && go mod download && make build && export DEBUG=true; make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
+ssh "${OPT[@]}" "$HOST" "export GOROOT=/usr/lib/golang; export PATH=\$GOROOT/bin:/usr/local/bin:\$PATH; echo \$PATH && cd /tmp/olm-addon && go version && kind version && go mod download && make build && export DEBUG=true; export UNFLAKE=true; make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
 if [[ $? -ne 0 ]]; then
   echo "Failure"
   cat $ARTIFACT_DIR/test.log


### PR DESCRIPTION
Add an UNFLAKE environment variable. If set to "true" the uninstall will be considered successful when the catalog deployment is deleted. Otherwise the e2e may time out.