### PR TITLE
Remove unncessary and prematurate kind load. Make e2e logs more verbose.

### DIFF
--- a/cicd/prow-e2e-kind.sh
+++ b/cicd/prow-e2e-kind.sh
@@ -39,18 +39,8 @@ echo "running e2e tests"
 echo "OLM image: $OLM_IMAGE"
 echo "CMS image: $CMS_IMAGE"
 
-if [[ -n "$OLM_IMAGE"   &&  -n "$CMS_IMAGE" ]]; then
-    ssh "${OPT[@]}" "$HOST" "docker pull $OLM_IMAGE; docker pull $CMS_IMAGE"
-    OLM_IMAGE_ID=${OLM_IMAGE%%@*}
-    CMS_IMAGE_ID=${CMS_IMAGE%%@*}
-    OLM_IMAGE_NEW="${OLM_IMAGE_ID%%:*}:test"
-    CMS_IMAGE_NEW="${CMS_IMAGE_ID%%:*}:test"
-    ssh "${OPT[@]}" "$HOST" "docker tag $OLM_IMAGE $OLM_IMAGE_NEW; docker tag $CMS_IMAGE $CMS_IMAGE_NEW"
-    ssh "${OPT[@]}" "$HOST" "/usr/bin/kind load docker-image $OLM_IMAGE_NEW; /usr/bin/kind load docker-image $CMS_IMAGE_NEW"
-fi
-
 set -o pipefail
-ssh "${OPT[@]}" "$HOST" "export GOROOT=/usr/lib/golang; export PATH=\$GOROOT/bin:/usr/local/bin:\$PATH; echo \$PATH && cd /tmp/olm-addon && go version && kind version && go mod download && make build && export DEBUG=true; export UNFLAKE=true; export OLM_IMAGE=$OLM_IMAGE_NEW; export CMS_IMAGE=$CMS_IMAGE_NEW; make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
+ssh "${OPT[@]}" "$HOST" "export GOROOT=/usr/lib/golang; export PATH=\$GOROOT/bin:/usr/local/bin:\$PATH; echo \$PATH && cd /tmp/olm-addon && go version && kind version && go mod download && make build && export DEBUG=true; export UNFLAKE=true; export OLM_IMAGE=$OLM_IMAGE; export CMS_IMAGE=$CMS_IMAGE; make e2e" 2>&1 | tee $ARTIFACT_DIR/test.log
 if [[ $? -ne 0 ]]; then
     echo "Failure"
     cat $ARTIFACT_DIR/test.log

--- a/test/e2e/framework/cluster.go
+++ b/test/e2e/framework/cluster.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -95,7 +94,7 @@ func ProvisionCluster(t *testing.T) *testCluster {
 		cmd := exec.Command(commandLine[0], commandLine[1:]...)
 		version, err := cmd.CombinedOutput()
 		require.NoError(t, err, "failed retrieving cluster version: %s", string(version))
-		logf(t, "Using existing cluster configured through the environment variable TEST_KUBECONFIG: %s", kcfg)
+		Logf(t, "Using existing cluster configured through the environment variable TEST_KUBECONFIG: %s", kcfg)
 		TestCluster.kubeconfig = kcfg
 		TestCluster.started = true
 		TestCluster.ready = true
@@ -120,7 +119,7 @@ func KindCluster(t *testing.T) *testCluster {
 		return TestCluster
 	}
 	if TestCluster.debug {
-		logf(t, "DEBUG environment variable is set to true. Filesystem and cluster will need be be cleaned up manually.")
+		Logf(t, "DEBUG environment variable is set to true. Filesystem and cluster will need be be cleaned up manually.")
 	}
 
 	commandLine := []string{"kind", "create", "cluster", "--name", "olm-addon-e2e", "--wait", "60s"}
@@ -134,7 +133,7 @@ func KindCluster(t *testing.T) *testCluster {
 			commandLine := []string{"kind", "delete", "cluster", "--name", "olm-addon-e2e"}
 			cmd := exec.Command(commandLine[0], commandLine[1:]...)
 			if err := cmd.Run(); err != nil {
-				logf(t, "kind cluster could not get deleted: %v", err)
+				Logf(t, "kind cluster could not get deleted: %v", err)
 			}
 		})
 	}
@@ -147,7 +146,7 @@ func KindCluster(t *testing.T) *testCluster {
 
 	TestCluster.kubeconfig = path.Join(TestCluster.testDir, "olm-addon-e2e.kubeconfig")
 	TestCluster.ready = true
-	logf(t, "kind cluster ready, artifacts in %s", TestCluster.testDir)
+	Logf(t, "kind cluster ready, artifacts in %s", TestCluster.testDir)
 
 	return TestCluster
 }
@@ -217,7 +216,7 @@ func deployOCM(t *testing.T) {
 	output, err = cmd.CombinedOutput()
 	require.NoError(t, err, "failed making the hub to accept the hosting cluster: %s", string(output))
 
-	logf(t, "OCM provisioned")
+	Logf(t, "OCM provisioned")
 }
 
 func deployAddonManager(t *testing.T) {
@@ -277,21 +276,17 @@ func deployOLMAddon(t *testing.T) {
 	err = cmd.Start()
 	TestCluster.cleanFuncs = append(TestCluster.cleanFuncs, func() {
 		if err := cmd.Process.Kill(); err != nil {
-			logf(t, "failed to kill controller: %v", err)
+			Logf(t, "failed to kill controller: %v", err)
 		}
 	})
 	require.NoError(t, err, "failed to start olm-addon controller")
-	logf(t, "olm-addon running")
+	Logf(t, "olm-addon running")
 }
 
 // cleanup runs the functions for cleaning up in reverse order
 func (tc *testCluster) cleanup() {
-	logf(tc.t, "Cleaning up")
+	Logf(tc.t, "Cleaning up")
 	for i := range tc.cleanFuncs {
 		tc.cleanFuncs[len(tc.cleanFuncs)-1-i]()
 	}
-}
-
-func logf(t *testing.T, format string, args ...any) {
-	t.Logf("%s: "+format, append([]any{time.Now().Format(time.RFC3339)}, args...)...)
 }

--- a/test/e2e/framework/log.go
+++ b/test/e2e/framework/log.go
@@ -1,0 +1,10 @@
+package framework
+
+import (
+	"testing"
+	"time"
+)
+
+func Logf(t *testing.T, format string, args ...any) {
+	t.Logf("%s: "+format, append([]any{time.Now().Format(time.RFC3339)}, args...)...)
+}

--- a/test/e2e/manager/manager_test.go
+++ b/test/e2e/manager/manager_test.go
@@ -65,6 +65,9 @@ func TestInstallation(t *testing.T) {
 	if cmsImage == "" {
 		cmsImage = "quay.io/operator-framework/configmap-operator-registry:v1.27.0"
 	}
+	framework.Logf(t, "OLM image %s", olmImage)
+	framework.Logf(t, "CMS image %s", cmsImage)
+
 	adc := addOnDeploymentConfig(olmImage, cmsImage)
 	_, err = addonClient.AddOnDeploymentConfigs("cluster1").Create(ctx, adc, metav1.CreateOptions{})
 	require.NoError(t, err, "failed creating the addondeploymentconfig")


### PR DESCRIPTION
The code in the CI script was trying to execute `kind load` before the cluster was created.